### PR TITLE
Remove site-root parameter. This coupling isn't required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Code Coverage](https://scrutinizer-ci.com/g/silverstripe-platform/blowgun/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/silverstripe-platform/blowgun/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/silverstripe-platform/blowgun/badges/build.png?b=master)](https://scrutinizer-ci.com/g/silverstripe-platform/blowgun/build-status/master)
 
-
 Blowgun is a library and tool to send and receive messages from AWS SQS. It's
 mean to be deployed to an AWS web instance and fetch messages that 'commands' 
 the instance to run jobs or tasks.
@@ -14,7 +13,7 @@ the instance to run jobs or tasks.
 Start a queue subscriber like this:
 
 ```bash
-./bin/blowgun listen local `whoami` dev --node-name mynode --site-root ~/Sites/silverstripe.dev --script-dir ../scripts/
+./bin/blowgun listen local `whoami` dev --node-name mynode --script-dir ../scripts/
 ```
 
 This will create and fetch messages from two SQS queues:
@@ -23,12 +22,10 @@ This will create and fetch messages from two SQS queues:
  2. local-{whoami}-dev-instance-mynode
  
 Since the behaviour of a SQS is that only one instance will normally receive and
-work on a message, there are two different uses for these queues: 
+work on a message, there are two different uses for these queues:
  
 The first queue is for messages where it doesn't matter which instance does the
 action, for example snapshot actions.
 
-The second queue is for messages that targets an individual instance. This can 
+The second queue is for messages that targets an individual instance. This can
 be used to ensure that all instances goes into maintenance mode.
-
-

--- a/src/SilverStripe/BlowGun/Command/ListenCommand.php
+++ b/src/SilverStripe/BlowGun/Command/ListenCommand.php
@@ -24,11 +24,6 @@ class ListenCommand extends BaseCommand {
 	/**
 	 * @var string
 	 */
-	protected $siteRoot = '';
-
-	/**
-	 * @var string
-	 */
 	protected $scriptDir = '';
 
 	/**
@@ -47,7 +42,6 @@ class ListenCommand extends BaseCommand {
 		$this->addArgument('cluster');
 		$this->addArgument('stack');
 		$this->addArgument('env');
-		$this->addOption('site-root', null, InputOption::VALUE_REQUIRED);
 		$this->addOption('script-dir', null, InputOption::VALUE_REQUIRED);
 		$this->addOption('node-name', null, InputOption::VALUE_REQUIRED);
 	}
@@ -63,7 +57,6 @@ class ListenCommand extends BaseCommand {
 		parent::execute($input, $output);
 
 		$this->queueService = new SQSHandler($this->profile, $this->region, $this->log);
-		$this->siteRoot = $this->getDirectoryFromInput($input, 'site-root');
 		$this->scriptDir = $this->getDirectoryFromInput($input, 'script-dir');
 		$this->nodeName = $input->getOption('node-name');
 
@@ -157,7 +150,7 @@ class ListenCommand extends BaseCommand {
 		}
 
 		$this->logNotice(sprintf('Running job %s', $message->getType()), $message);
-		$command = new Command($message, $this->scriptDir, $this->siteRoot);
+		$command = new Command($message, $this->scriptDir);
 		$status = $command->run();
 
 		foreach($status->getErrors() as $error) {

--- a/src/SilverStripe/BlowGun/Model/Command.php
+++ b/src/SilverStripe/BlowGun/Model/Command.php
@@ -24,12 +24,10 @@ class Command {
 	/**
 	 * @param Message $message
 	 * @param string $scriptDir
-	 * @param string $siteRoot
 	 */
-	public function __construct(Message $message, $scriptDir, $siteRoot) {
+	public function __construct(Message $message, $scriptDir) {
 		$this->message = $message;
 		$this->scriptDir = $scriptDir;
-		$this->siteRoot = $siteRoot;
 		$this->process = $this->getProcess();
 	}
 
@@ -67,7 +65,6 @@ class Command {
 				$builder->setEnv($name, $value);
 			}
 		}
-		$builder->setEnv('webroot', $this->siteRoot);
 		$process = $builder->getProcess();
 		$process->setTimeout(3600);
 		return $process;


### PR DESCRIPTION
Removing this gives us the ability to use blowgun in environments that
don't specifically have a website running in them. For example, you
might just want to run a remote command on a server.

Current scripts don't actually use the "webroot" parameter anyway, so we
won't really miss this site-root setting.